### PR TITLE
remove redundant prefix -- from boundary

### DIFF
--- a/stream.c
+++ b/stream.c
@@ -955,7 +955,7 @@ static void stream_add_client(struct stream *list, int sc)
                                  "Cache-Control: no-cache, private\r\n"
                                  "Pragma: no-cache\r\n"
                                  "Content-Type: multipart/x-mixed-replace; "
-                                 "boundary=--BoundaryString\r\n\r\n";
+                                 "boundary=BoundaryString\r\n\r\n";
 
     memset(new, 0, sizeof(struct stream));
     new->socket = sc;


### PR DESCRIPTION
The boundary string that separates each message-parts is same as one in Content-Type header.
According to RFC, the boundary as message-part separator must be prefixed "--".
http://www.w3.org/Protocols/rfc1341/7_2_Multipart.html
In this reason some browser such as Chrome are not work well.
