### PR TITLE
Bugfix for RTSP. Segfault after unsuccessful connect

### DIFF
--- a/netcam.c
+++ b/netcam.c
@@ -2418,6 +2418,7 @@ static int netcam_setup_rtsp(netcam_context_ptr netcam, struct url_t *url)
 {
   struct context *cnt = netcam->cnt;
   const char *ptr;
+  int ret = -1;
   
   netcam->caps.streaming = NCS_RTSP;
   netcam->rtsp = rtsp_new_context();
@@ -2470,7 +2471,8 @@ static int netcam_setup_rtsp(netcam_context_ptr netcam, struct url_t *url)
    * The RTSP context should be all ready to attempt a connection with
    * the server, so we try ....
    */
-  rtsp_connect(netcam);
+  ret = rtsp_connect(netcam);
+  if (ret < 0) return ret;
 
   netcam->get_image = netcam_read_rtsp_image;
 

--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -189,7 +189,7 @@ int rtsp_connect(netcam_context_ptr netcam)
     MOTION_LOG(ALR, TYPE_NETCAM, NO_ERRNO, "%s: unable to open input(%s): %d - %s", netcam->rtsp->path, ret, av_err2str(ret));
     rtsp_free_context(netcam->rtsp);
     netcam->rtsp = NULL;
-    return -1;
+    return ret;
   }
 
   // fill out stream information


### PR DESCRIPTION
Even if connect failed we still return 0 which is wrong.
Instead we should return same negative value which we got from "avformat_open_input".
