### PR TITLE
Add auth support to rtsp:// netcam

### DIFF
--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -184,6 +184,7 @@ int rtsp_connect(netcam_context_ptr netcam)
   AVDictionary *opts = 0;
   av_dict_set(&opts, "rtsp_transport", "tcp", 0);
 
+  avformat_network_init();
   int ret = avformat_open_input(&netcam->rtsp->format_context, netcam->rtsp->path, NULL, &opts);
   if (ret < 0) {
     MOTION_LOG(ALR, TYPE_NETCAM, NO_ERRNO, "%s: unable to open input(%s): %d - %s", netcam->rtsp->path, ret, av_err2str(ret));


### PR DESCRIPTION
The ffmpeg code expects the auth info to be part of the url that is
passed to it. This constructs the url using either the netcam_userpass
configuration option, or if that is missing from the auth data
parsed from the netcam_url option.

This also adds a call to avformat_network_init() in rtsp_connect to
quiet a deprecation warning.
